### PR TITLE
Update ASM to support newer Java versions

### DIFF
--- a/common-transform/pom.xml
+++ b/common-transform/pom.xml
@@ -47,7 +47,6 @@
 
 
     <properties>
-        <asm.version>7.3.1</asm.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -65,7 +64,6 @@
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm</artifactId>
-            <version>${asm.version}</version>
         </dependency>
 
 

--- a/plugin.sync.bug/pom.xml
+++ b/plugin.sync.bug/pom.xml
@@ -47,7 +47,6 @@
 
 
     <properties>
-        <asm.version>7.3.1</asm.version>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
         <encoding>UTF-8</encoding>
@@ -69,7 +68,6 @@
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm</artifactId>
-            <version>${asm.version}</version>
         </dependency>
 
 

--- a/vmlens/pom.xml
+++ b/vmlens/pom.xml
@@ -41,7 +41,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <asm.version>7.3.1</asm.version>
+        <asm.version>9.4</asm.version>
     </properties>
 
     <distributionManagement>

--- a/vmlens/pom.xml
+++ b/vmlens/pom.xml
@@ -41,7 +41,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <asm.version>7.1</asm.version>
+        <asm.version>7.3.1</asm.version>
     </properties>
 
     <distributionManagement>
@@ -65,6 +65,16 @@
         <module>../plugin.sync.bug</module>
         <module>../interleave</module>
     </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm</artifactId>
+                <version>${asm.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
 
     <profiles>

--- a/vmlens/pom.xml
+++ b/vmlens/pom.xml
@@ -41,7 +41,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <asm.version>9.4</asm.version>
+        <asm.version>9.5</asm.version>
     </properties>
 
     <distributionManagement>


### PR DESCRIPTION
This is the first step for #8. ASM 9.4 supports Java up to version 20. When I run the examples with this change I now get an error in the vmlens code regarding reflective access.

```
java.lang.ExceptionInInitializerError
	at org.gradle.internal.service.DefaultServiceRegistry$OwnServices.<init>(DefaultServiceRegistry.java:391)
	at org.gradle.internal.service.DefaultServiceRegistry.<init>(DefaultServiceRegistry.java:107)
	at org.gradle.internal.service.DefaultServiceRegistry.<init>(DefaultServiceRegistry.java:94)
	at org.gradle.internal.logging.services.LoggingServiceRegistry.<init>(LoggingServiceRegistry.java:47)
	at org.gradle.internal.logging.services.LoggingServiceRegistry$CommandLineLogging.<init>(LoggingServiceRegistry.java:157)
	at org.gradle.internal.logging.services.LoggingServiceRegistry$CommandLineLogging.<init>(LoggingServiceRegistry.java:157)
	at org.gradle.internal.logging.services.LoggingServiceRegistry.newEmbeddableLogging(LoggingServiceRegistry.java:101)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:90)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:71)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)
Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make field private final java.util.concurrent.locks.ReentrantLock$Sync java.util.concurrent.locks.ReentrantLock.sync accessible: module java.base does not "opens java.util.concurrent.locks" to unnamed module @e6ea0c6
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354)
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
	at java.base/java.lang.reflect.Field.checkCanSetAccessible(Field.java:178)
	at java.base/java.lang.reflect.Field.setAccessible(Field.java:172)
	at com.vmlens.trace.agent.bootstrap.callback.LockTemplateCallback.getSync(LockTemplateCallback.java:559)
	at com.vmlens.trace.agent.bootstrap.callback.LockTemplateCallback.lock(LockTemplateCallback.java:137)
	at java.base/java.util.concurrent.LinkedBlockingQueue.drainTo(LinkedBlockingQueue.java:706)
	at org.slf4j.LoggerFactory.replayEvents(LoggerFactory.java:211)
	at org.slf4j.LoggerFactory.postBindCleanUp(LoggerFactory.java:183)
	at org.slf4j.LoggerFactory.bind(LoggerFactory.java:177)
	at org.slf4j.LoggerFactory.performInitialization(LoggerFactory.java:124)
	at org.slf4j.LoggerFactory.getILoggerFactory(LoggerFactory.java:417)
	at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:362)
	at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:388)
	at org.gradle.internal.concurrent.CompositeStoppable.<clinit>(CompositeStoppable.java:37)
	... 11 more
```

Would be great if someone with deeper knowlegde about the vmlens inner workings can pick it up from here.


PS: I had to comment out building with the trace-agent-bootstrap-test module due to compile errors even before my changes in `BlockFactoryModel.scala` and `TestLogger.scala`. Don't know if this is only an issue with my setup.