### PR TITLE
CVE-2017-15288: Scala-lang version upgrade to latest

### DIFF
--- a/plugin.sync.bug/pom.xml
+++ b/plugin.sync.bug/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
-            <version>2.13.2</version>
+            <version>2.13.11</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Version bump to latest scala-lang patch number.

Reason: Vulnerability CVE-2017-15288 remediation within the scala-reflect:2.11.11.jar used by scala-lang:2.13.2