### PR TITLE
Fix missing space

### DIFF
--- a/standalone/src/main/java/com/vmlens/Install.java
+++ b/standalone/src/main/java/com/vmlens/Install.java
@@ -13,6 +13,6 @@ public class Install implements Runnable {
     @Override
     public void run() {
         EventDirectoryAndArgLine result = new SetupAgent(parent.agentDirectory, "").setup();
-        System.out.println("use " + result.argLine() + "as vm parameter");
+        System.out.println("use \"" + result.argLine() + "\" as vm parameter");
     }
 }


### PR DESCRIPTION
Adds a missing space and some quotes to the output of the install command to make it easier to copy the vm parameter